### PR TITLE
Allow empty string as delimiter for `split`

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -288,26 +288,36 @@ public final class StringFunctions
             VARCHAR.writeSlice(parts, string);
             return parts.build();
         }
-
+        
         int index = 0;
-        while (index < string.length()) {
-            int splitIndex = string.indexOf(delimiter, index);
-            // Found split?
-            if (splitIndex < 0) {
+        
+        if (delimeter.length()==0){ 
+            //When the delimeter is an empty string you dont need the splitIndex fuction.
+            while (index < string.length()) { 
+                 VARCHAR.writeSlice(parts, string, index, index);
+                 index++;
+            }  
+          
+        } else if (delimeter.length()==0) {
+            while (index < string.length()) {
+                int splitIndex = string.indexOf(delimiter, index);
+                // Found split?
+                if (splitIndex < 0) {
                 break;
-            }
-            // Add the part from current index to found split
-            VARCHAR.writeSlice(parts, string, index, splitIndex - index);
-            // Continue searching after delimiter
-            index = splitIndex + delimiter.length();
-            // Reached limit-1 parts so we can stop
-            if (parts.getPositionCount() == limit - 1) {
-                break;
-            }
-        }
+                }
+                // Add the part from current index to found split
+                VARCHAR.writeSlice(parts, string, index, splitIndex - index);
+                // Continue searching after delimiter
+                index = splitIndex + delimiter.length();
+                // Reached limit-1 parts so we can stop
+                if (parts.getPositionCount() == limit - 1) {
+                     break;
+                }
+            }               
         // Rest of string
         VARCHAR.writeSlice(parts, string, index, string.length() - index);
-
+        
+        }
         return parts.build();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestRegexpFunctions.java
@@ -163,7 +163,7 @@ public class TestRegexpFunctions
         assertFunction("REGEXP_SPLIT('a1b2c3d', '\\d')", new ArrayType(VARCHAR), ImmutableList.of("a", "b", "c", "d"));
         assertFunction("REGEXP_SPLIT('a1b2346c3d', '\\d+')", new ArrayType(VARCHAR), ImmutableList.of("a", "b", "c", "d"));
         assertFunction("REGEXP_SPLIT('abcd', 'x')", new ArrayType(VARCHAR), ImmutableList.of("abcd"));
-        assertFunction("REGEXP_SPLIT('abcd', '')", new ArrayType(VARCHAR), ImmutableList.of("", "a", "b", "c", "d", ""));
+        assertFunction("REGEXP_SPLIT('abcd', '')", new ArrayType(VARCHAR), ImmutableList.of("a", "b", "c", "d"));
         assertFunction("REGEXP_SPLIT('', 'x')", new ArrayType(VARCHAR), ImmutableList.of(""));
 
         // test empty splits, leading & trailing empty splits, consecutive empty splits


### PR DESCRIPTION
Split function and regex_split
